### PR TITLE
Rename app from ChangeLog to ChangeKeeper across entire codebase

### DIFF
--- a/CHANGEKEEPER.md
+++ b/CHANGEKEEPER.md
@@ -1,4 +1,4 @@
-# Changelog
+# Changekeeper
 
 ## Version 2.0.0 - Production Ready (2026-02-04)
 
@@ -50,8 +50,8 @@
 
 ```bash
 # Extract and deploy
-unzip changelog-v2.zip
-cd changelog-v2
+unzip changekeeper-v2.zip
+cd changekeeper-v2
 cp .env.example .env
 # Edit .env with your Azure AD credentials
 docker-compose up -d

--- a/FIXES_APPLIED.md
+++ b/FIXES_APPLIED.md
@@ -124,7 +124,7 @@ change = Change(
 2. `app/main.py` - Middleware configuration
 3. `app/routers/changes.py` - Form handling and validation
 4. `README.md` - Complete rewrite with fixes documented
-5. `CHANGELOG.md` - Version history
+5. `CHANGEKEEPER.md` - Version history
 
 ## Upgrade Path from V1
 
@@ -132,12 +132,12 @@ change = Change(
 
 1. Backup V1 database:
    ```bash
-   docker-compose exec db pg_dump -U changelog_user changelog > v1_backup.sql
+   docker-compose exec db pg_dump -U changekeeper_user changekeeper > v1_backup.sql
    ```
 
 2. Deploy V2:
    ```bash
-   cd changelog-v2
+   cd changekeeper-v2
    cp .env.example .env
    # Configure .env
    docker-compose up -d
@@ -145,7 +145,7 @@ change = Change(
 
 3. (Optional) Migrate data:
    ```bash
-   docker-compose exec -T db psql -U changelog_user changelog < v1_backup.sql
+   docker-compose exec -T db psql -U changekeeper_user changekeeper < v1_backup.sql
    ```
 
 ## Known Working Configurations

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 ChangeLog Contributors
+Copyright (c) 2025 ChangeKeeper Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -1,4 +1,4 @@
-# ChangeLog MVP - Project Summary
+# ChangeKeeper MVP - Project Summary
 
 ## ✅ Deliverables Completed
 
@@ -34,7 +34,7 @@
 ## 📁 Project Structure
 
 ```
-changelog/
+changekeeper/
 ├── app/
 │   ├── auth/               # Authentication & authorization
 │   ├── routers/            # API endpoints & page routes
@@ -80,10 +80,10 @@ docker-compose up --build
 
 ```bash
 # 1. Copy files to server
-scp -r changelog user@server:/opt/
+scp -r changekeeper user@server:/opt/
 
 # 2. Configure environment
-cd /opt/changelog
+cd /opt/changekeeper
 cp .env.example .env
 # Edit .env for production
 
@@ -92,7 +92,7 @@ cp .env.example .env
 # 4. Start application
 docker-compose -f docker-compose.prod.yml up -d
 
-# 5. Access at https://changelog.yourdomain.com
+# 5. Access at https://changekeeper.yourdomain.com
 ```
 
 ## 🔑 Key Features Implemented

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,4 +1,4 @@
-# ChangeLog - Quick Start Guide
+# ChangeKeeper - Quick Start Guide
 
 ## 5-Minute Setup
 
@@ -14,7 +14,7 @@ docker-compose --version
 ### 2. Get the Code
 ```bash
 git clone <your-repo-url>
-cd changelog
+cd changekeeper
 ```
 
 ### 3. Configure Microsoft Entra ID
@@ -23,7 +23,7 @@ cd changelog
 
 1. Go to https://portal.azure.com → Azure Active Directory → App registrations
 2. Click "New registration"
-   - Name: `ChangeLog`
+   - Name: `ChangeKeeper`
    - Redirect URI: `Web` → `http://localhost:8000/auth/callback`
 3. After creation, note these values:
    - Application (client) ID
@@ -118,7 +118,7 @@ docker-compose down
 docker-compose restart app
 
 # Backup database
-docker-compose exec db pg_dump -U changelog_user changelog > backup.sql
+docker-compose exec db pg_dump -U changekeeper_user changekeeper > backup.sql
 
 # Reset everything (⚠️ destroys data)
 docker-compose down -v

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ChangeLog - IT Change Management System
+# ChangeKeeper - IT Change Management System
 
 A lightweight, secure web application for K–12 IT teams to record, track, and report on operational changes. Built with FastAPI and designed for easy deployment using Docker Compose.
 
@@ -35,7 +35,7 @@ A lightweight, secure web application for K–12 IT teams to record, track, and 
 
 ```bash
 git clone <repository-url>
-cd changelog
+cd changekeeper
 cp .env.example .env
 ```
 
@@ -45,7 +45,7 @@ cp .env.example .env
 
 1. Go to [Azure Portal](https://portal.azure.com) → Azure Active Directory → App registrations
 2. Click "New registration"
-3. Name: `ChangeLog`
+3. Name: `ChangeKeeper`
 4. Supported account types: `Accounts in this organizational directory only`
 5. Redirect URI: `Web` → `http://localhost:8000/auth/callback`
 6. Click "Register"
@@ -55,7 +55,7 @@ cp .env.example .env
 1. Copy **Application (client) ID** → This is your `ENTRA_CLIENT_ID`
 2. Copy **Directory (tenant) ID** → This is your `ENTRA_TENANT_ID`
 3. Go to "Certificates & secrets" → "New client secret"
-4. Description: `ChangeLog Secret`
+4. Description: `ChangeKeeper Secret`
 5. Expires: Choose expiration (12-24 months recommended)
 6. Copy the **Value** → This is your `ENTRA_CLIENT_SECRET` (save it now, you can't see it again!)
 
@@ -94,7 +94,7 @@ ENTRA_TENANT_ID=<your-tenant-id>
 REDIRECT_URI=http://localhost:8000/auth/callback
 
 # Database (already configured for Docker Compose)
-DATABASE_URL=postgresql://changelog_user:changelog_password@db:5432/changelog
+DATABASE_URL=postgresql://changekeeper_user:changekeeper_password@db:5432/changekeeper
 
 # Email (Optional - leave disabled for MVP)
 ENABLE_EMAIL=false
@@ -168,8 +168,8 @@ sudo sh get-docker.sh
 sudo apt install docker-compose -y
 
 # Create application directory
-sudo mkdir -p /opt/changelog
-cd /opt/changelog
+sudo mkdir -p /opt/changekeeper
+cd /opt/changekeeper
 ```
 
 2. **Clone and configure:**
@@ -186,31 +186,31 @@ nano .env
 **Production `.env` changes:**
 ```env
 SECRET_KEY=<generate-new-secure-key>
-REDIRECT_URI=https://changelog.yourdomain.com/auth/callback
+REDIRECT_URI=https://changekeeper.yourdomain.com/auth/callback
 # ... other settings
 ```
 
 3. **Update Entra ID Redirect URI:**
 
-Go to Azure Portal → App registrations → ChangeLog → Authentication
-- Add redirect URI: `https://changelog.yourdomain.com/auth/callback`
+Go to Azure Portal → App registrations → ChangeKeeper → Authentication
+- Add redirect URI: `https://changekeeper.yourdomain.com/auth/callback`
 
 4. **Configure reverse proxy (Nginx):**
 
 ```nginx
-# /etc/nginx/sites-available/changelog
+# /etc/nginx/sites-available/changekeeper
 server {
     listen 80;
-    server_name changelog.yourdomain.com;
+    server_name changekeeper.yourdomain.com;
     return 301 https://$server_name$request_uri;
 }
 
 server {
     listen 443 ssl http2;
-    server_name changelog.yourdomain.com;
+    server_name changekeeper.yourdomain.com;
 
-    ssl_certificate /etc/letsencrypt/live/changelog.yourdomain.com/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/changelog.yourdomain.com/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/changekeeper.yourdomain.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/changekeeper.yourdomain.com/privkey.pem;
     
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers HIGH:!aNULL:!MD5;
@@ -230,7 +230,7 @@ server {
 
 Enable site:
 ```bash
-sudo ln -s /etc/nginx/sites-available/changelog /etc/nginx/sites-enabled/
+sudo ln -s /etc/nginx/sites-available/changekeeper /etc/nginx/sites-enabled/
 sudo nginx -t
 sudo systemctl reload nginx
 ```
@@ -249,28 +249,28 @@ docker-compose logs -f app
 
 ```bash
 # Create backup script
-sudo nano /opt/changelog/backup.sh
+sudo nano /opt/changekeeper/backup.sh
 ```
 
 ```bash
 #!/bin/bash
-BACKUP_DIR="/backup/changelog"
+BACKUP_DIR="/backup/changekeeper"
 DATE=$(date +%Y%m%d_%H%M%S)
 mkdir -p $BACKUP_DIR
 
 # Backup database
-docker-compose exec -T db pg_dump -U changelog_user changelog | gzip > $BACKUP_DIR/changelog_$DATE.sql.gz
+docker-compose exec -T db pg_dump -U changekeeper_user changekeeper | gzip > $BACKUP_DIR/changekeeper_$DATE.sql.gz
 
 # Keep last 30 days
-find $BACKUP_DIR -name "changelog_*.sql.gz" -mtime +30 -delete
+find $BACKUP_DIR -name "changekeeper_*.sql.gz" -mtime +30 -delete
 ```
 
 ```bash
-sudo chmod +x /opt/changelog/backup.sh
+sudo chmod +x /opt/changekeeper/backup.sh
 
 # Add to crontab (daily at 2 AM)
 sudo crontab -e
-# Add: 0 2 * * * /opt/changelog/backup.sh
+# Add: 0 2 * * * /opt/changekeeper/backup.sh
 ```
 
 ### Production Security Checklist
@@ -381,9 +381,9 @@ To enable email notifications:
 ENABLE_EMAIL=true
 SMTP_HOST=smtp.office365.com
 SMTP_PORT=587
-SMTP_USER=changelog@yourdomain.com
+SMTP_USER=changekeeper@yourdomain.com
 SMTP_PASSWORD=<app-password>
-SMTP_FROM=changelog@yourdomain.com
+SMTP_FROM=changekeeper@yourdomain.com
 ```
 
 2. Restart application:
@@ -427,7 +427,7 @@ docker-compose ps
 docker-compose logs db
 
 # Verify connection
-docker-compose exec db psql -U changelog_user -d changelog
+docker-compose exec db psql -U changekeeper_user -d changekeeper
 ```
 
 **Reset database (⚠️ destroys data):**

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,2 +1,2 @@
-# ChangeLog Application
+# ChangeKeeper Application
 __version__ = "1.0.0"

--- a/app/config.py
+++ b/app/config.py
@@ -28,11 +28,11 @@ class Settings(BaseSettings):
     smtp_from: str = ""
     
     # Session
-    session_cookie_name: str = "changelog_session"
+    session_cookie_name: str = "changekeeper_session"
     session_max_age: int = 86400  # 24 hours
     
     # Application
-    app_name: str = "ChangeLog"
+    app_name: str = "ChangeKeeper"
     
     class Config:
         env_file = ".env"

--- a/app/routers/reports.py
+++ b/app/routers/reports.py
@@ -136,7 +136,7 @@ async def export_changes_csv(
     
     # Prepare response
     output.seek(0)
-    filename = f"changelog_export_{start}_to_{end}.csv"
+    filename = f"changekeeper_export_{start}_to_{end}.csv"
     
     return StreamingResponse(
         iter([output.getvalue()]),

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1,4 +1,4 @@
-/* ChangeLog CSS */
+/* ChangeKeeper CSS */
 
 :root {
     --primary-color: #0078d4;

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}ChangeLog{% endblock %}</title>
+    <title>{% block title %}ChangeKeeper{% endblock %}</title>
     <link rel="stylesheet" href="/static/css/style.css">
     {% block extra_head %}{% endblock %}
 </head>
@@ -12,7 +12,7 @@
     <nav class="navbar">
         <div class="nav-container">
             <div class="nav-brand">
-                <a href="/">ChangeLog</a>
+                <a href="/">ChangeKeeper</a>
             </div>
             <div class="nav-menu">
                 <a href="/" class="nav-link">Dashboard</a>

--- a/app/templates/change_detail.html
+++ b/app/templates/change_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Change #{{ change.id }} - ChangeLog{% endblock %}
+{% block title %}Change #{{ change.id }} - ChangeKeeper{% endblock %}
 
 {% block content %}
 <div class="change-detail">

--- a/app/templates/change_wizard.html
+++ b/app/templates/change_wizard.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}New Change - ChangeLog{% endblock %}
+{% block title %}New Change - ChangeKeeper{% endblock %}
 
 {% block content %}
 <div class="wizard-container">

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Dashboard - ChangeLog{% endblock %}
+{% block title %}Dashboard - ChangeKeeper{% endblock %}
 
 {% block content %}
 <div class="dashboard">

--- a/app/templates/error.html
+++ b/app/templates/error.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Error - ChangeLog</title>
+    <title>Error - ChangeKeeper</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Login - ChangeLog</title>
+    <title>Login - ChangeKeeper</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
 <body class="login-page">
     <div class="login-container">
         <div class="login-box">
-            <h1>ChangeLog</h1>
+            <h1>ChangeKeeper</h1>
             <p class="subtitle">IT Change Management System</p>
             
             <div class="login-content">

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,24 +7,24 @@ services:
   db:
     image: postgres:15-alpine
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-changelog}
-      POSTGRES_USER: ${POSTGRES_USER:-changelog_user}
+      POSTGRES_DB: ${POSTGRES_DB:-changekeeper}
+      POSTGRES_USER: ${POSTGRES_USER:-changekeeper_user}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}  # Must be set in .env
     volumes:
       - postgres_data:/var/lib/postgresql/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-changelog_user} -d ${POSTGRES_DB:-changelog}"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-changekeeper_user} -d ${POSTGRES_DB:-changekeeper}"]
       interval: 10s
       timeout: 5s
       retries: 5
     networks:
-      - changelog_network
+      - changekeeper_network
 
   app:
     build: .
     environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-changelog_user}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-changelog}
+      - DATABASE_URL=postgresql://${POSTGRES_USER:-changekeeper_user}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-changekeeper}
       - SECRET_KEY=${SECRET_KEY}
       - ENTRA_CLIENT_ID=${ENTRA_CLIENT_ID}
       - ENTRA_CLIENT_SECRET=${ENTRA_CLIENT_SECRET}
@@ -48,7 +48,7 @@ services:
         uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 4
       "
     networks:
-      - changelog_network
+      - changekeeper_network
     ports:
       - "127.0.0.1:8000:8000"  # Only expose to localhost; use reverse proxy
 
@@ -57,5 +57,5 @@ volumes:
     driver: local
 
 networks:
-  changelog_network:
+  changekeeper_network:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,15 +4,15 @@ services:
   db:
     image: postgres:15-alpine
     environment:
-      POSTGRES_DB: changelog
-      POSTGRES_USER: changelog_user
-      POSTGRES_PASSWORD: changelog_password
+      POSTGRES_DB: changekeeper
+      POSTGRES_USER: changekeeper_user
+      POSTGRES_PASSWORD: changekeeper_password
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U changelog_user -d changelog"]
+      test: ["CMD-SHELL", "pg_isready -U changekeeper_user -d changekeeper"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -22,7 +22,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - DATABASE_URL=postgresql://changelog_user:changelog_password@db:5432/changelog
+      - DATABASE_URL=postgresql://changekeeper_user:changekeeper_password@db:5432/changekeeper
       - SECRET_KEY=${SECRET_KEY}
       - ENTRA_CLIENT_ID=${ENTRA_CLIENT_ID}
       - ENTRA_CLIENT_SECRET=${ENTRA_CLIENT_SECRET}

--- a/env.example
+++ b/env.example
@@ -1,5 +1,5 @@
 # Database Configuration
-DATABASE_URL=postgresql://changelog_user:changelog_password@db:5432/changelog
+DATABASE_URL=postgresql://changekeeper_user:changekeeper_password@db:5432/changekeeper
 
 # Application Security
 SECRET_KEY=your-secret-key-here-generate-with-openssl-rand-hex-32
@@ -16,4 +16,4 @@ SMTP_HOST=smtp.example.com
 SMTP_PORT=587
 SMTP_USER=your-smtp-username
 SMTP_PASSWORD=your-smtp-password
-SMTP_FROM=changelog@example.com
+SMTP_FROM=changekeeper@example.com


### PR DESCRIPTION
Replace all instances of changelog/ChangeLog/Changelog/CHANGELOG with
changekeeper/ChangeKeeper/Changekeeper/CHANGEKEEPER preserving original
capitalization patterns. Includes source code, templates, config files,
Docker configs, and documentation.

https://claude.ai/code/session_018c8RQAZzoiFiDifV2qfLMt